### PR TITLE
Enable incremental build when building Generator from source

### DIFF
--- a/build_generator
+++ b/build_generator
@@ -6,6 +6,9 @@ set -e
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 pushd "${DIR}/Generator"
-rm -rf .build
+if [[ ! -z "$CLEAN" ]]; then
+    rm -rf .build
+fi
+
 env -i PATH="$PATH" HOME="$HOME" xcrun swift build --configuration release "$@"
 popd

--- a/run
+++ b/run
@@ -39,7 +39,7 @@ function build_generator {
   else
     if [[ -d "$SCRIPT_PATH/Generator" ]]; then
       echo "Building..."
-      ./build_generator
+      env -i CLEAN="$CLEAN" ./build_generator
       if [[ "$?" -ne 0 ]]; then
         echo "Build seems to have failed for some reason. Please file an issue on GitHub."
         exit 1
@@ -81,6 +81,12 @@ case $1 in
     shift
   ;;
 
+  -b|--build)
+    BUILD=1
+    echo "Building from source."
+    shift
+  ;;
+
   *)
     POSITIONAL+=("$1") # save it in an array for later
     shift
@@ -89,8 +95,7 @@ esac
 done
 set -- "${POSITIONAL[@]}" # restore positional parameters
 
-if [[ ! -e "$FILE_PATH" ]] || [[ ! -z "$CLEAN" ]]; then
-  echo "No Cuckoo Generator found."
+if [[ ! -e "$FILE_PATH" ]] || [[ ! -z "$BUILD" ]] || [[ ! -z "$CLEAN" ]]; then
   build_generator "$DOWNLOAD"
 fi
 


### PR DESCRIPTION
# Problem
As long as the generator is not released officially we have to build it from source.
Currently the only way is to perform a clean build every single time. This causes building tests to take much longer.

# Changes
I implemented `-b`/`--build` flags to enable building from source without cleaning.