### PR TITLE
Fix autoclosure code generator

### DIFF
--- a/Generator/Source/Internal/Tokens/Method.swift
+++ b/Generator/Source/Internal/Tokens/Method.swift
@@ -67,7 +67,7 @@ public extension Method {
 
     func serialize() -> [String : Any] {
         let call = parameters.map {
-            let referencedName = "\($0.isInout ? "&" : "")\($0.name)"
+            let referencedName = "\($0.isInout ? "&" : "")\($0.name)\($0.isAutoClosure ? "()" : "")"
             if let label = $0.label {
                 return "\(label): \(referencedName)"
             } else {

--- a/Generator/Source/Internal/Tokens/MethodParameter.swift
+++ b/Generator/Source/Internal/Tokens/MethodParameter.swift
@@ -27,6 +27,10 @@ public struct MethodParameter: Token, Equatable {
         return typeWithoutAttributes.hasPrefix("(") && typeWithoutAttributes.range(of: "->") != nil
     }
 
+    public var isAutoClosure: Bool {
+        type.containsAttribute(named: "@autoclosure")
+    }
+
     public var isOptional: Bool {
         return type.isOptional
     }

--- a/Tests/Swift/ClassTest.swift
+++ b/Tests/Swift/ClassTest.swift
@@ -157,6 +157,7 @@ class ClassTest: XCTestCase {
 
         stub(mock) { mock in
             when(mock.withClosure(anyClosure())).then { $0("a") }
+            when(mock.withAutoClosure(action: anyClosure())).then { $0() }
             when(mock.withClosureReturningVoid(anyClosure())).then { $0("a")() }
             when(mock.withClosureReturningInt(anyClosure())).then { $0("a")(1) }
             when(mock.withOptionalClosureAlone(anyClosure())).then { $0?("a")(1) ?? 1 }
@@ -165,6 +166,7 @@ class ClassTest: XCTestCase {
         }
 
         XCTAssertEqual(mock.withClosure { _ in 1 }, 1)
+        XCTAssertEqual(mock.withAutoClosure(action: 1), 1)
         XCTAssertEqual(mock.withClosureReturningVoid {_ in { return 1 } }, 1)
         XCTAssertEqual(mock.withClosureReturningInt { _ in { _ in return 1 } }, 1)
         XCTAssertEqual(mock.withOptionalClosureAlone { _ in { _ in return 1 } }, 1)
@@ -172,6 +174,7 @@ class ClassTest: XCTestCase {
         XCTAssertEqual(mock.withNestedClosure2 { _ in { _ in return 1 } }, 1)
 
         verify(mock).withClosure(anyClosure())
+        verify(mock).withAutoClosure(action: anyClosure())
         verify(mock).withClosureReturningVoid(anyClosure())
         verify(mock).withClosureReturningInt(anyClosure())
         verify(mock).withOptionalClosureAlone(anyClosure())

--- a/Tests/Swift/Source/TestedClass.swift
+++ b/Tests/Swift/Source/TestedClass.swift
@@ -109,6 +109,10 @@ class TestedClass {
         return closure("hello")
     }
 
+    func withAutoClosure(action closure: @autoclosure () -> Int) -> Int {
+        return closure()
+    }
+
     func withClosureReturningVoid(_ closure: (String) -> () -> Int) -> Int {
         return closure("hello")()
     }

--- a/Tests/Swift/Source/TestedProtocol.swift
+++ b/Tests/Swift/Source/TestedProtocol.swift
@@ -44,6 +44,8 @@ protocol TestedProtocol {
 
     func withClosure(_ closure: (String) -> Int) -> Int
 
+    func withAutoClosure(action closure: @autoclosure () -> Int) -> Int
+
     func withClosureAndParam(_ a: String, closure:(String) -> Int) -> Int
 
     func withEscape(_ a: String, action closure: @escaping (String) -> Void)

--- a/Tests/Swift/Stubbing/StubbingTest.swift
+++ b/Tests/Swift/Stubbing/StubbingTest.swift
@@ -227,6 +227,7 @@ class StubbingTest: XCTestCase {
                 callNoReturnThrows = true
             }
             when(stub.withClosure(anyClosure())).thenReturn(14)
+            when(stub.withAutoClosure(action: anyClosure())).thenReturn(16)
             when(stub.withEscape(anyString(), action: anyClosure())).then { _ in
                 callWithEscape = true
             }
@@ -289,6 +290,7 @@ class StubbingTest: XCTestCase {
         XCTAssertEqual(mock.withClosure { _ in
             41
         }, 14)
+        XCTAssertEqual(mock.withAutoClosure(action: 42), 16)
         XCTAssertTrue({
             mock.withEscape("a") { _ in }
             return callWithEscape
@@ -337,6 +339,7 @@ class StubbingTest: XCTestCase {
         verify(mock, times(1)).count(characters: anyString())
         verify(mock, times(1)).withNoReturnThrows()
         verify(mock, times(1)).withClosure(anyClosure())
+        verify(mock, times(1)).withAutoClosure(action: anyClosure())
         verify(mock, times(1)).withEscape(anyString(), action: anyClosure())
         verify(mock, times(1)).withOptionalClosure(anyString(), closure: anyClosure())
         verify(mock, times(1)).withLabelAndUnderscore(labelA: anyString(), anyString())


### PR DESCRIPTION
# Description
## Problem
When a protocol using an `@autoclosure` is used, the generated code is invalid as `@autoclosure` closures need a `()` when forwarding.

![Screenshot 2023-01-18 at 13 36 48](https://user-images.githubusercontent.com/6216959/213173149-fe65d0bc-18e7-4ca7-b602-3d0187e4a05b.png)

## Changes
This PR extends the `MethodParameter` to detect an `@autoclosure` and handles it accordingly when generating.

![Screenshot 2023-01-18 at 13 38 32](https://user-images.githubusercontent.com/6216959/213173510-a3756786-7d7e-4048-b1ad-b5c161be8d48.png)

## Tests
- Added an example method to the `TestedProtocol` to cover this
- Added simple unit tests for mocking